### PR TITLE
Make interfaces for Client and all Resources

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,9 +60,9 @@ type RealClient struct {
 }
 
 // NewClient creates a new Client.
-func NewClient(host string, user string, pass string, httpsMode bool) Client {
+func NewClient(host string, user string, pass string, insecureHTTPS bool) Client {
 	httpClient := new(http.Client)
-	if httpsMode {
+	if insecureHTTPS {
 		httpClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}

--- a/client.go
+++ b/client.go
@@ -5,64 +5,83 @@ import (
 	"net/http"
 )
 
-// vars
+// Client describes behavior of the root Kubernetes client object.
+type Client interface {
+	// Namespaces returns a NamespaceCollection.
+	Namespaces() NamespaceCollection
+
+	// Events returns a EventCollection.
+	Events(namespace string) EventCollection
+
+	// Secrets returns a SecretCollection.
+	Secrets(namespace string) SecretCollection
+
+	// Services returns a ServiceCollection.
+	Services(namespace string) ServiceCollection
+
+	// ReplicationControllers returns a ReplicationControllerCollection.
+	ReplicationControllers(namespace string) ReplicationControllerCollection
+
+	// Pods returns a PodCollection.
+	Pods(namespace string) PodCollection
+
+	// Nodes returns a NodeCollection.
+	Nodes() NodeCollection
+}
+
 var (
 	defaultAPIGroup   = "api"
 	defaultAPIVersion = "v1"
 )
 
-// Interfaces
-
-// Entity is a data holder, usually used for holding json data objects
 type Entity interface {
 }
 
-// Collection holds interfaces to kubernetes api artifacts.
-type Collection interface {
-	DomainName() string // empty unless something like ThirdPartyResource
-	APIGroup() string   // usually "api"
-	APIVersion() string // usually "v1"
-	APIName() string    // e.g. "replicationcontrollers"
-	Kind() string       // e.g. "ReplicationController"
+// CollectionMeta holds info required by all Kubernetes Resources defined.
+type CollectionMeta struct {
+	DomainName string // empty unless something like ThirdPartyResource
+	APIGroup   string // usually "api"
+	APIVersion string // usually "v1"
+	APIName    string // e.g. "replicationcontrollers"
+	Kind       string // e.g. "ReplicationController"
 }
 
-// structs
+// Collection defines an interface for collections of Kubernetes resources.
+type Collection interface {
+	Meta() *CollectionMeta
+}
 
-// Client is a kubernetes client object.
-type Client struct {
+// RealClient implements Client.
+type RealClient struct {
 	Host     string
 	Username string
 	Password string
 	http     *http.Client
 }
 
-//Functions
-
-// NewClient creates a new kubernetes client object.
-func NewClient(host string, user string, pass string, httpsMode bool) *Client {
+// NewClient creates a new Client.
+func NewClient(host string, user string, pass string, httpsMode bool) Client {
+	httpClient := new(http.Client)
 	if httpsMode {
-		tr := &http.Transport{
+		httpClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
-		return &Client{host, user, pass, &http.Client{Transport: tr}}
 	}
-	return &Client{host, user, pass, &http.Client{}}
+	return &RealClient{host, user, pass, httpClient}
 }
 
-//Methods
-
 // Get performs a GET request against a Client object.
-func (c *Client) Get() *Request {
+func (c *RealClient) Get() *Request {
 	return &Request{client: c, method: "GET"}
 }
 
 // Post performs a POST request against a Client object.
-func (c *Client) Post() *Request {
+func (c *RealClient) Post() *Request {
 	return &Request{client: c, method: "POST"}
 }
 
 // Patch performs a PATCH request against a Client object.
-func (c *Client) Patch() *Request {
+func (c *RealClient) Patch() *Request {
 	return &Request{
 		client: c,
 		method: "PATCH",
@@ -73,36 +92,41 @@ func (c *Client) Patch() *Request {
 }
 
 // Delete performs a DELETE request against a Client object.
-func (c *Client) Delete() *Request {
+func (c *RealClient) Delete() *Request {
 	return &Request{client: c, method: "DELETE"}
 }
 
 // Namespaces returns a Namespaces object from a Client object.
-func (c *Client) Namespaces() *Namespaces {
+func (c *RealClient) Namespaces() NamespaceCollection {
 	return &Namespaces{c}
 }
 
 // Events returns a Events object from a Client object.
-func (c *Client) Events(namespace string) *Events {
+func (c *RealClient) Events(namespace string) EventCollection {
 	return &Events{c, namespace}
 }
 
 // Secrets returns a Secrets object from a Client object.
-func (c *Client) Secrets(namespace string) *Secrets {
+func (c *RealClient) Secrets(namespace string) SecretCollection {
 	return &Secrets{c, namespace}
 }
 
 // Services returns a Services object from a Client object.
-func (c *Client) Services(namespace string) *Services {
+func (c *RealClient) Services(namespace string) ServiceCollection {
 	return &Services{c, namespace}
 }
 
 // ReplicationControllers returns a ReplicationControllers object from a Client object.
-func (c *Client) ReplicationControllers(namespace string) *ReplicationControllers {
+func (c *RealClient) ReplicationControllers(namespace string) ReplicationControllerCollection {
 	return &ReplicationControllers{c, namespace}
 }
 
 // Pods returns a Pods object from a Client object.
-func (c *Client) Pods(namespace string) *Pods {
+func (c *RealClient) Pods(namespace string) PodCollection {
 	return &Pods{c, namespace}
+}
+
+// Namespaces returns a Nodes object from a Client object.
+func (c *RealClient) Nodes() NodeCollection {
+	return &Nodes{c}
 }

--- a/events.go
+++ b/events.go
@@ -1,34 +1,38 @@
 package guber
 
+// EventCollection is a Collection interface for Events.
+type EventCollection interface {
+	Meta() *CollectionMeta
+	New() *Event
+	Create(e *Event) (*Event, error)
+	Query(q *QueryParams) (*EventList, error)
+	List() (*EventList, error)
+	Get(name string) (*Event, error)
+	Update(name string, r *Event) (*Event, error)
+	Delete(name string) (found bool, err error)
+}
+
+// Events implmenets EventCollection.
 type Events struct {
-	client    *Client
+	client    *RealClient
 	Namespace string
+}
+
+// Meta implements the Collection interface.
+func (c *Events) Meta() *CollectionMeta {
+	return &CollectionMeta{
+		DomainName: "",
+		APIGroup:   "api",
+		APIVersion: "v1",
+		APIName:    "events",
+		Kind:       "Event",
+	}
 }
 
 func (c *Events) New() *Event {
 	return &Event{
 		collection: c,
 	}
-}
-
-func (c Events) DomainName() string {
-	return ""
-}
-
-func (c Events) APIGroup() string {
-	return "api"
-}
-
-func (c Events) APIVersion() string {
-	return "v1"
-}
-
-func (c Events) APIName() string {
-	return "events"
-}
-
-func (c Events) Kind() string {
-	return "Event"
 }
 
 func (c *Events) Create(e *Event) (*Event, error) {

--- a/events_test.go
+++ b/events_test.go
@@ -18,56 +18,6 @@ var (
 	}
 )
 
-func TestEventsDomainName(t *testing.T) {
-	Convey("When calling the .DomainName() on an Events object.", t, func() {
-		resp := tevents.DomainName()
-		Convey("We should expect to get a blank string return.", func() {
-			expected := ""
-			So(resp, ShouldEqual, expected)
-		})
-	})
-}
-
-func TestEventsAPIGroup(t *testing.T) {
-	Convey("When calling the .APIGroup() on an Events object.", t, func() {
-		resp := tevents.APIGroup()
-		Convey("We should expect to get a string \"api\" return.", func() {
-			expected := "api"
-			So(resp, ShouldEqual, expected)
-		})
-	})
-}
-
-func TestEventsAPIVersion(t *testing.T) {
-	Convey("When calling the .APIVersion() on an Events object.", t, func() {
-		resp := tevents.APIVersion()
-		Convey("We should expect to get a string \"v1\" return.", func() {
-			expected := "v1"
-			So(resp, ShouldEqual, expected)
-		})
-	})
-}
-
-func TestEventsAPIName(t *testing.T) {
-	Convey("When calling the .APIName() on an Events object.", t, func() {
-		resp := tevents.APIName()
-		Convey("We should expect to get a string \"events\" return.", func() {
-			expected := "events"
-			So(resp, ShouldEqual, expected)
-		})
-	})
-}
-
-func TestEventsKind(t *testing.T) {
-	Convey("When calling the .Kind() on an Events object.", t, func() {
-		resp := tevents.Kind()
-		Convey("We should expect to get a string \"Event\" return.", func() {
-			expected := "Event"
-			So(resp, ShouldEqual, expected)
-		})
-	})
-}
-
 func TestEventsCreate(t *testing.T) {
 	Convey("We start a mock api server.", t, func() {
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/namespaces.go
+++ b/namespaces.go
@@ -1,33 +1,37 @@
 package guber
 
+// NamespaceCollection is a Collection interface for Namespaces.
+type NamespaceCollection interface {
+	Meta() *CollectionMeta
+	New() *Namespace
+	Create(e *Namespace) (*Namespace, error)
+	Query(q *QueryParams) (*NamespaceList, error)
+	List() (*NamespaceList, error)
+	Get(name string) (*Namespace, error)
+	Update(name string, r *Namespace) (*Namespace, error)
+	Delete(name string) (found bool, err error)
+}
+
+// Namespaces implements NamespaceCollection.
 type Namespaces struct {
-	client *Client
+	client *RealClient
+}
+
+// Meta implements the Collection interface.
+func (c *Namespaces) Meta() *CollectionMeta {
+	return &CollectionMeta{
+		DomainName: "",
+		APIGroup:   "api",
+		APIVersion: "v1",
+		APIName:    "namespaces",
+		Kind:       "Namespace",
+	}
 }
 
 func (c *Namespaces) New() *Namespace {
 	return &Namespace{
 		collection: c,
 	}
-}
-
-func (c Namespaces) DomainName() string {
-	return ""
-}
-
-func (c Namespaces) APIGroup() string {
-	return "api"
-}
-
-func (c Namespaces) APIVersion() string {
-	return "v1"
-}
-
-func (c Namespaces) APIName() string {
-	return "namespaces"
-}
-
-func (c Namespaces) Kind() string {
-	return "Namespace"
 }
 
 func (c *Namespaces) Create(e *Namespace) (*Namespace, error) {

--- a/nodes.go
+++ b/nodes.go
@@ -1,33 +1,37 @@
 package guber
 
+// NodeCollection is a Collection interface for Nodes.
+type NodeCollection interface {
+	Meta() *CollectionMeta
+	New() *Node
+	Create(e *Node) (*Node, error)
+	Query(q *QueryParams) (*NodeList, error)
+	List() (*NodeList, error)
+	Get(name string) (*Node, error)
+	Update(name string, r *Node) (*Node, error)
+	Delete(name string) (found bool, err error)
+}
+
+// Nodes implmenets NodeCollection.
 type Nodes struct {
-	client *Client
+	client *RealClient
+}
+
+// Meta implements the Collection interface.
+func (c *Nodes) Meta() *CollectionMeta {
+	return &CollectionMeta{
+		DomainName: "",
+		APIGroup:   "api",
+		APIVersion: "v1",
+		APIName:    "nodes",
+		Kind:       "Node",
+	}
 }
 
 func (c *Nodes) New() *Node {
 	return &Node{
 		collection: c,
 	}
-}
-
-func (c Nodes) DomainName() string {
-	return ""
-}
-
-func (c Nodes) APIGroup() string {
-	return "api"
-}
-
-func (c Nodes) APIVersion() string {
-	return "v1"
-}
-
-func (c Nodes) APIName() string {
-	return "nodes"
-}
-
-func (c Nodes) Kind() string {
-	return "Node"
 }
 
 func (c *Nodes) Create(e *Node) (*Node, error) {

--- a/pods.go
+++ b/pods.go
@@ -1,34 +1,38 @@
 package guber
 
+// PodCollection is a Collection interface for Pods.
+type PodCollection interface {
+	Meta() *CollectionMeta
+	New() *Pod
+	Create(e *Pod) (*Pod, error)
+	Query(q *QueryParams) (*PodList, error)
+	List() (*PodList, error)
+	Get(name string) (*Pod, error)
+	Update(name string, r *Pod) (*Pod, error)
+	Delete(name string) (found bool, err error)
+}
+
+// Pods implmenets PodCollection.
 type Pods struct {
-	client    *Client
+	client    *RealClient
 	Namespace string
+}
+
+// Meta implements the Collection interface.
+func (c *Pods) Meta() *CollectionMeta {
+	return &CollectionMeta{
+		DomainName: "",
+		APIGroup:   "api",
+		APIVersion: "v1",
+		APIName:    "pods",
+		Kind:       "Pod",
+	}
 }
 
 func (c *Pods) New() *Pod {
 	return &Pod{
 		collection: c,
 	}
-}
-
-func (c Pods) DomainName() string {
-	return ""
-}
-
-func (c Pods) APIGroup() string {
-	return "api"
-}
-
-func (c Pods) APIVersion() string {
-	return "v1"
-}
-
-func (c Pods) APIName() string {
-	return "pods"
-}
-
-func (c Pods) Kind() string {
-	return "Pod"
 }
 
 func (c *Pods) Create(e *Pod) (*Pod, error) {

--- a/replication_controllers.go
+++ b/replication_controllers.go
@@ -1,34 +1,38 @@
 package guber
 
+// ReplicationControllerCollection is a Collection interface for ReplicationControllers.
+type ReplicationControllerCollection interface {
+	Meta() *CollectionMeta
+	New() *ReplicationController
+	Create(e *ReplicationController) (*ReplicationController, error)
+	Query(q *QueryParams) (*ReplicationControllerList, error)
+	List() (*ReplicationControllerList, error)
+	Get(name string) (*ReplicationController, error)
+	Update(name string, r *ReplicationController) (*ReplicationController, error)
+	Delete(name string) (found bool, err error)
+}
+
+// ReplicationControllers implmenets ReplicationControllerCollection.
 type ReplicationControllers struct {
-	client    *Client
+	client    *RealClient
 	Namespace string
+}
+
+// Meta implements the Collection interface.
+func (c *ReplicationControllers) Meta() *CollectionMeta {
+	return &CollectionMeta{
+		DomainName: "",
+		APIGroup:   "api",
+		APIVersion: "v1",
+		APIName:    "replicationcontrollers",
+		Kind:       "ReplicationController",
+	}
 }
 
 func (c *ReplicationControllers) New() *ReplicationController {
 	return &ReplicationController{
 		collection: c,
 	}
-}
-
-func (c ReplicationControllers) DomainName() string {
-	return ""
-}
-
-func (c ReplicationControllers) APIGroup() string {
-	return "api"
-}
-
-func (c ReplicationControllers) APIVersion() string {
-	return "v1"
-}
-
-func (c ReplicationControllers) APIName() string {
-	return "replicationcontrollers"
-}
-
-func (c ReplicationControllers) Kind() string {
-	return "ReplicationController"
 }
 
 func (c *ReplicationControllers) Create(e *ReplicationController) (*ReplicationController, error) {

--- a/secrets.go
+++ b/secrets.go
@@ -1,34 +1,38 @@
 package guber
 
+// SecretCollection is a Collection interface for Secrets.
+type SecretCollection interface {
+	Meta() *CollectionMeta
+	New() *Secret
+	Create(e *Secret) (*Secret, error)
+	Query(q *QueryParams) (*SecretList, error)
+	List() (*SecretList, error)
+	Get(name string) (*Secret, error)
+	Update(name string, r *Secret) (*Secret, error)
+	Delete(name string) (found bool, err error)
+}
+
+// Secrets implmenets SecretCollection.
 type Secrets struct {
-	client    *Client
+	client    *RealClient
 	Namespace string
+}
+
+// Meta implements the Collection interface.
+func (c *Secrets) Meta() *CollectionMeta {
+	return &CollectionMeta{
+		DomainName: "",
+		APIGroup:   "api",
+		APIVersion: "v1",
+		APIName:    "secrets",
+		Kind:       "Secret",
+	}
 }
 
 func (c *Secrets) New() *Secret {
 	return &Secret{
 		collection: c,
 	}
-}
-
-func (c Secrets) DomainName() string {
-	return ""
-}
-
-func (c Secrets) APIGroup() string {
-	return "api"
-}
-
-func (c Secrets) APIVersion() string {
-	return "v1"
-}
-
-func (c Secrets) APIName() string {
-	return "secrets"
-}
-
-func (c Secrets) Kind() string {
-	return "Secret"
 }
 
 func (c *Secrets) Create(e *Secret) (*Secret, error) {

--- a/services.go
+++ b/services.go
@@ -1,34 +1,38 @@
 package guber
 
+// ServiceCollection is a Collection interface for Services.
+type ServiceCollection interface {
+	Meta() *CollectionMeta
+	New() *Service
+	Create(e *Service) (*Service, error)
+	Query(q *QueryParams) (*ServiceList, error)
+	List() (*ServiceList, error)
+	Get(name string) (*Service, error)
+	Update(name string, r *Service) (*Service, error)
+	Delete(name string) (found bool, err error)
+}
+
+// Services implmenets ServiceCollection.
 type Services struct {
-	client    *Client
+	client    *RealClient
 	Namespace string
+}
+
+// Meta implements the Collection interface.
+func (c *Services) Meta() *CollectionMeta {
+	return &CollectionMeta{
+		DomainName: "",
+		APIGroup:   "api",
+		APIVersion: "v1",
+		APIName:    "services",
+		Kind:       "Service",
+	}
 }
 
 func (c *Services) New() *Service {
 	return &Service{
 		collection: c,
 	}
-}
-
-func (c Services) DomainName() string {
-	return ""
-}
-
-func (c Services) APIGroup() string {
-	return "api"
-}
-
-func (c Services) APIVersion() string {
-	return "v1"
-}
-
-func (c Services) APIName() string {
-	return "services"
-}
-
-func (c Services) Kind() string {
-	return "Service"
 }
 
 func (c *Services) Create(e *Service) (*Service, error) {


### PR DESCRIPTION
@spankenstein Breaking change guber.NewClient() returns a guber.Client instead of
*guber.Client. Client was renamed to RealClient, and Client is now an
interface.