### PR TITLE
Return Error404 on failed GETs, only return error on DELETE

### DIFF
--- a/events.go
+++ b/events.go
@@ -9,7 +9,7 @@ type EventCollection interface {
 	List() (*EventList, error)
 	Get(name string) (*Event, error)
 	Update(name string, r *Event) (*Event, error)
-	Delete(name string) (found bool, err error)
+	Delete(name string) error
 }
 
 // Events implmenets EventCollection.
@@ -67,14 +67,10 @@ func (c *Events) List() (*EventList, error) {
 
 func (c *Events) Get(name string) (*Event, error) {
 	r := c.New()
-	req := c.client.Get().Collection(c).Namespace(c.Namespace).Name(name).Do()
-	if err := req.Into(r); err != nil {
+	if err := c.client.Get().Collection(c).Namespace(c.Namespace).Name(name).Do().Into(r); err != nil {
 		return nil, err
 	}
-	if req.found {
-		return r, nil
-	}
-	return nil, nil
+	return r, nil
 }
 
 func (c *Events) Update(name string, r *Event) (*Event, error) {
@@ -84,9 +80,9 @@ func (c *Events) Update(name string, r *Event) (*Event, error) {
 	return r, nil
 }
 
-func (c *Events) Delete(name string) (found bool, err error) {
+func (c *Events) Delete(name string) error {
 	req := c.client.Delete().Collection(c).Namespace(c.Namespace).Name(name).Do()
-	return req.found, req.err
+	return req.err
 }
 
 // Resource-level
@@ -101,6 +97,5 @@ func (r *Event) Save() error {
 }
 
 func (r *Event) Delete() error {
-	_, err := r.collection.Delete(r.Metadata.Name)
-	return err
+	return r.collection.Delete(r.Metadata.Name)
 }

--- a/namespaces.go
+++ b/namespaces.go
@@ -9,7 +9,7 @@ type NamespaceCollection interface {
 	List() (*NamespaceList, error)
 	Get(name string) (*Namespace, error)
 	Update(name string, r *Namespace) (*Namespace, error)
-	Delete(name string) (found bool, err error)
+	Delete(name string) error
 }
 
 // Namespaces implements NamespaceCollection.
@@ -66,14 +66,10 @@ func (c *Namespaces) List() (*NamespaceList, error) {
 
 func (c *Namespaces) Get(name string) (*Namespace, error) {
 	r := c.New()
-	req := c.client.Get().Collection(c).Name(name).Do()
-	if err := req.Into(r); err != nil {
+	if err := c.client.Get().Collection(c).Name(name).Do().Into(r); err != nil {
 		return nil, err
 	}
-	if req.found {
-		return r, nil
-	}
-	return nil, nil
+	return r, nil
 }
 
 func (c *Namespaces) Update(name string, r *Namespace) (*Namespace, error) {
@@ -83,9 +79,9 @@ func (c *Namespaces) Update(name string, r *Namespace) (*Namespace, error) {
 	return r, nil
 }
 
-func (c *Namespaces) Delete(name string) (found bool, err error) {
+func (c *Namespaces) Delete(name string) error {
 	req := c.client.Delete().Collection(c).Name(name).Do()
-	return req.found, req.err
+	return req.err
 }
 
 // Resource-level
@@ -100,6 +96,5 @@ func (r *Namespace) Save() error {
 }
 
 func (r *Namespace) Delete() error {
-	_, err := r.collection.Delete(r.Metadata.Name)
-	return err
+	return r.collection.Delete(r.Metadata.Name)
 }

--- a/pods.go
+++ b/pods.go
@@ -9,7 +9,7 @@ type PodCollection interface {
 	List() (*PodList, error)
 	Get(name string) (*Pod, error)
 	Update(name string, r *Pod) (*Pod, error)
-	Delete(name string) (found bool, err error)
+	Delete(name string) error
 }
 
 // Pods implmenets PodCollection.
@@ -67,14 +67,10 @@ func (c *Pods) List() (*PodList, error) {
 
 func (c *Pods) Get(name string) (*Pod, error) {
 	r := c.New()
-	req := c.client.Get().Collection(c).Namespace(c.Namespace).Name(name).Do()
-	if err := req.Into(r); err != nil {
+	if err := c.client.Get().Collection(c).Namespace(c.Namespace).Name(name).Do().Into(r); err != nil {
 		return nil, err
 	}
-	if req.found {
-		return r, nil
-	}
-	return nil, nil
+	return r, nil
 }
 
 func (c *Pods) Update(name string, r *Pod) (*Pod, error) {
@@ -84,9 +80,9 @@ func (c *Pods) Update(name string, r *Pod) (*Pod, error) {
 	return r, nil
 }
 
-func (c *Pods) Delete(name string) (found bool, err error) {
+func (c *Pods) Delete(name string) error {
 	req := c.client.Delete().Collection(c).Namespace(c.Namespace).Name(name).Do()
-	return req.found, req.err
+	return req.err
 }
 
 // Resource-level
@@ -101,8 +97,7 @@ func (r *Pod) Save() error {
 }
 
 func (r *Pod) Delete() error {
-	_, err := r.collection.Delete(r.Metadata.Name)
-	return err
+	return r.collection.Delete(r.Metadata.Name)
 }
 
 func (r *Pod) Log(container string) (string, error) {

--- a/replication_controllers.go
+++ b/replication_controllers.go
@@ -9,7 +9,7 @@ type ReplicationControllerCollection interface {
 	List() (*ReplicationControllerList, error)
 	Get(name string) (*ReplicationController, error)
 	Update(name string, r *ReplicationController) (*ReplicationController, error)
-	Delete(name string) (found bool, err error)
+	Delete(name string) error
 }
 
 // ReplicationControllers implmenets ReplicationControllerCollection.
@@ -67,14 +67,10 @@ func (c *ReplicationControllers) List() (*ReplicationControllerList, error) {
 
 func (c *ReplicationControllers) Get(name string) (*ReplicationController, error) {
 	r := c.New()
-	req := c.client.Get().Collection(c).Namespace(c.Namespace).Name(name).Do()
-	if err := req.Into(r); err != nil {
+	if err := c.client.Get().Collection(c).Namespace(c.Namespace).Name(name).Do().Into(r); err != nil {
 		return nil, err
 	}
-	if req.found {
-		return r, nil
-	}
-	return nil, nil
+	return r, nil
 }
 
 func (c *ReplicationControllers) Update(name string, r *ReplicationController) (*ReplicationController, error) {
@@ -84,9 +80,9 @@ func (c *ReplicationControllers) Update(name string, r *ReplicationController) (
 	return r, nil
 }
 
-func (c *ReplicationControllers) Delete(name string) (found bool, err error) {
+func (c *ReplicationControllers) Delete(name string) error {
 	req := c.client.Delete().Collection(c).Namespace(c.Namespace).Name(name).Do()
-	return req.found, req.err
+	return req.err
 }
 
 // Resource-level
@@ -101,6 +97,5 @@ func (r *ReplicationController) Save() error {
 }
 
 func (r *ReplicationController) Delete() error {
-	_, err := r.collection.Delete(r.Metadata.Name)
-	return err
+	return r.collection.Delete(r.Metadata.Name)
 }

--- a/secrets.go
+++ b/secrets.go
@@ -9,7 +9,7 @@ type SecretCollection interface {
 	List() (*SecretList, error)
 	Get(name string) (*Secret, error)
 	Update(name string, r *Secret) (*Secret, error)
-	Delete(name string) (found bool, err error)
+	Delete(name string) error
 }
 
 // Secrets implmenets SecretCollection.
@@ -67,14 +67,10 @@ func (c *Secrets) List() (*SecretList, error) {
 
 func (c *Secrets) Get(name string) (*Secret, error) {
 	r := c.New()
-	req := c.client.Get().Collection(c).Namespace(c.Namespace).Name(name).Do()
-	if err := req.Into(r); err != nil {
+	if err := c.client.Get().Collection(c).Namespace(c.Namespace).Name(name).Do().Into(r); err != nil {
 		return nil, err
 	}
-	if req.found {
-		return r, nil
-	}
-	return nil, nil
+	return r, nil
 }
 
 func (c *Secrets) Update(name string, r *Secret) (*Secret, error) {
@@ -84,9 +80,9 @@ func (c *Secrets) Update(name string, r *Secret) (*Secret, error) {
 	return r, nil
 }
 
-func (c *Secrets) Delete(name string) (found bool, err error) {
+func (c *Secrets) Delete(name string) error {
 	req := c.client.Delete().Collection(c).Namespace(c.Namespace).Name(name).Do()
-	return req.found, req.err
+	return req.err
 }
 
 // Resource-level
@@ -101,6 +97,5 @@ func (r *Secret) Save() error {
 }
 
 func (r *Secret) Delete() error {
-	_, err := r.collection.Delete(r.Metadata.Name)
-	return err
+	return r.collection.Delete(r.Metadata.Name)
 }

--- a/services.go
+++ b/services.go
@@ -9,7 +9,7 @@ type ServiceCollection interface {
 	List() (*ServiceList, error)
 	Get(name string) (*Service, error)
 	Update(name string, r *Service) (*Service, error)
-	Delete(name string) (found bool, err error)
+	Delete(name string) error
 }
 
 // Services implmenets ServiceCollection.
@@ -67,14 +67,10 @@ func (c *Services) List() (*ServiceList, error) {
 
 func (c *Services) Get(name string) (*Service, error) {
 	r := c.New()
-	req := c.client.Get().Collection(c).Namespace(c.Namespace).Name(name).Do()
-	if err := req.Into(r); err != nil {
+	if err := c.client.Get().Collection(c).Namespace(c.Namespace).Name(name).Do().Into(r); err != nil {
 		return nil, err
 	}
-	if req.found {
-		return r, nil
-	}
-	return nil, nil
+	return r, nil
 }
 
 func (c *Services) Update(name string, r *Service) (*Service, error) {
@@ -84,9 +80,9 @@ func (c *Services) Update(name string, r *Service) (*Service, error) {
 	return r, nil
 }
 
-func (c *Services) Delete(name string) (found bool, err error) {
+func (c *Services) Delete(name string) error {
 	req := c.client.Delete().Collection(c).Namespace(c.Namespace).Name(name).Do()
-	return req.found, req.err
+	return req.err
 }
 
 // Resource-level
@@ -101,6 +97,5 @@ func (r *Service) Save() error {
 }
 
 func (r *Service) Delete() error {
-	_, err := r.collection.Delete(r.Metadata.Name)
-	return err
+	return r.collection.Delete(r.Metadata.Name)
 }

--- a/types.go
+++ b/types.go
@@ -43,9 +43,15 @@ type NodeStatusCondition struct {
 	Status string `json:"status"`
 }
 
+type NodeAddress struct {
+	Type    string `json:"type"`
+	Address string `json:"address"`
+}
+
 type NodeStatus struct {
 	Capacity   *NodeStatusCapacity    `json:"capacity"`
 	Conditions []*NodeStatusCondition `json:"conditions"`
+	Addresses  []*NodeAddress         `json:"addresses"`
 }
 
 type Node struct {


### PR DESCRIPTION
This commit introduces a breaking change, explained here:

**Replace this:**
```go
namespace, err := gubr.Namespaces().Get(name)
if err != nil {
  panic(err) // any error but 404
}
if namespace == nil {
  // create namespace
}
found, err := namespace.Delete()
```

**With this:**
```go
namespace, err := gubr.Namespaces().Get(name)
if err != nil {
  if _, ok := err.(*guber.Error404); !ok {
    panic(err) // any error but 404
  }
}
if namespace == nil {
  // create namespace
}
// only 1 return arg on Delete() now
err := namespace.Delete()
```